### PR TITLE
Flickering in Header buttons due to screen size is fixed 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,15 +83,15 @@ nav a {
 
 nav a span {
     padding: 20px 0 20px 0;
-    border-top: .5px solid rgba(0,0,0,0);
-    border-bottom: .5px solid rgba(0,0,0,0);
-    transition: all .3s ease-in;
+    border-top:1px solid rgba(0,0,0,0);
+    border-bottom: 1px solid rgba(0,0,0,0);
+    transition: all 0.3s ease-in;
 }
 
 nav a span:hover {
     padding: 2px 0 2px 0;
-    border-top: .5px solid rgba(255,255,255,1);
-    border-bottom: .5px solid rgba(255,255,255,1);
+    border-top: 1px solid rgba(255,255,255,0.5);
+    border-bottom: 1px solid rgba(255,255,255,0.5);
 }
 
 nav .nav-light {

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,14 @@
+let elements = document.querySelectorAll("nav a");
+for (let i = 0; i < elements.length; i++) {
+	elements[i].style.paddingTop = `${
+		window.innerHeight / 10 - ((window.innerHeight / 10) % 1)
+	}px`;
+}
+
+window.addEventListener("resize", () => {
+	for (let i = 0; i < elements.length; i++) {
+		elements[i].style.paddingTop = `${
+			window.innerHeight / 10 - ((window.innerHeight / 10) % 1)
+		}px`;
+	}
+});


### PR DESCRIPTION
In some screens such as 10vh equals to a floating number and  this cause flickering, I fixed it with rounding it to integer because pixels cannot be lower than 1 in screen 